### PR TITLE
fix 'Page' object has no attribute 'querySelector'

### DIFF
--- a/playwright/example.py
+++ b/playwright/example.py
@@ -34,7 +34,7 @@ try:
             )
         ))
 
-        vrt.trackElementHandle(page.querySelector(".search-the-site"), "Search form", ElementHandleTrackOptions(
+        vrt.trackElementHandle(page.query_selector(".search-the-site"), "Search form", ElementHandleTrackOptions(
             diffTollerancePercent=1.34,
             ignoreAreas=[
                 IgnoreArea(


### PR DESCRIPTION
Resolve [issue #24](https://github.com/Visual-Regression-Tracker/sdk-python/issues/24)